### PR TITLE
Fix color of histograms in marginal hist.

### DIFF
--- a/src/cornerplot.jl
+++ b/src/cornerplot.jl
@@ -40,7 +40,7 @@
     margin    --> 1mm
     titlefont --> font(11)
     fillcolor --> Plots.fg_color(d)
-    fillcolor --> Plots.fg_color(d)
+    linecolor --> Plots.fg_color(d)
     grid      --> true
     ticks     := nothing
     formatter := v->""

--- a/src/marginalhist.jl
+++ b/src/marginalhist.jl
@@ -3,7 +3,7 @@
 @recipe function f(::Type{Val{:marginalhist}}, plt::Plot; density = false)
     x, y = d[:x], d[:y]
     delete!(d, :density)
-    
+
     # set up the subplots
     legend --> false
     link := :both
@@ -12,7 +12,7 @@
         tophist           _
         hist2d{0.9w,0.9h} righthist
     ]
-    
+
     # main histogram2d
     @series begin
         seriestype := :histogram2d
@@ -20,14 +20,13 @@
         top_margin --> 0mm
         subplot := 2
     end
-    
+
     # these are common to both marginal histograms
     ticks := nothing
     guide := ""
     foreground_color_subplot := RGBA(0,0,0,0)
-    fillcolor --> :black
-    fillalpha --> 0.3
-    linealpha --> 0.7
+    fillcolor --> Plots.fg_color(d)
+    linecolor --> Plots.fg_color(d)
 
     if density
         trim := true
@@ -35,14 +34,14 @@
     else
         seriestype := :histogram
     end
-    
+
     # upper histogram
     @series begin
         subplot := 1
         bottom_margin --> 0mm
         y := x
     end
-    
+
     # right histogram
     @series begin
         orientation := :h


### PR DESCRIPTION
![fix](https://cloud.githubusercontent.com/assets/8431156/19205525/4cb6f2c0-8ce3-11e6-9ae3-bcaf8448fef5.png)

they were black (with an alpha value) before, now they're fg as in the other plots. A typo also made its way into my previous pr, and that is fixed as well.

Why is there a border in the subplot to the right but now above by the way?