### PR TITLE
Added shaded error plots

### DIFF
--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -23,5 +23,6 @@ include("violin.jl")
 include("hist.jl")
 include("marginalhist.jl")
 include("bar.jl")
+include("shadederror.jl")
 
 end # module

--- a/src/shadederror.jl
+++ b/src/shadederror.jl
@@ -1,0 +1,106 @@
+function border(x,y,rib)
+    rib1, rib2 = if Plots.istuple(rib)
+        first(rib), last(rib)
+    else
+        rib, rib
+    end
+    yline = vcat(y-rib1,(y+rib2)[end:-1:1])
+    xline = vcat(x,x[end:-1:1])
+    return xline, yline
+end
+
+@recipe function f(::Type{Val{:shadederror}},plt::Plot; shade = 0.)
+
+    # set up the subplots
+    x,y = d[:x],d[:y]
+    xline, yline = border(x,y,shade)
+
+    # line plot
+    @series begin
+        primary := true
+        x := x
+        y := y
+        seriestype := :path
+        ()
+    end
+
+    @series begin
+        # shaded error bar
+        primary := false
+        fillrange := 0
+        fillalpha --> 0.5
+        linewidth := 0
+        x := xline
+        y := yline
+        seriestype := :path
+        ()
+    end
+end
+
+@shorthands shadederror
+
+## Define a more general shadederror function that can take as input:
+## - a function to be applied to your dataframe
+## - a dataframe
+## - the x-variable of the plot
+## - the categorical variable used to compute s.e.m. across population
+## - optionally, another categorical variable used to split the data
+
+get_axis(column::PooledDataArray) = sort!(union(column))
+get_axis(column::AbstractArray) = linspace(minimum(column),maximum(column),100)
+
+# f is the function used to analyze dataset: define it as NA when it is not defined,
+# the input is: dataframe used, x variable and points chosen on the x axis
+# the output is the y value for the given xvalues
+
+function get_mean_sem(f, df, x, population)
+    # define points on x axis
+    xvalues = get_axis(df[x])
+
+    # get mean value and sem of function of interest
+    splitdata = groupby(df, population)
+    v = DataArray(Float64, length(xvalues), length(splitdata));
+    for i in 1:length(splitdata)
+        v[:,i] = f(splitdata[i],x, xvalues)
+    end
+
+    mean_across_pop = DataArray(Float64, length(xvalues));
+    sem_across_pop = DataArray(Float64, length(xvalues));
+    valid = Array(Bool, length(xvalues));
+    for j in 1:length(xvalues)
+        mean_across_pop[j] = mean(dropna(v[j,:]))
+        sem_across_pop[j] = sem(dropna(v[j,:]))
+        valid[j] = (length(dropna(v[j,:]))>1)
+    end
+
+    return xvalues[valid], mean_across_pop[valid], sem_across_pop[valid]
+end
+
+function shadederror(f, df, x, population; kwargs...)
+    x,y, shade = get_mean_sem(f, df, x, population)
+    shadederror(x,y; shade = shade, kwargs...)
+end
+
+function shadederror!(f, df, x, population; kwargs...)
+    x,y, shade = get_mean_sem(f, df, x, population)
+    shadederror!(x,y; shade = shade, kwargs...)
+    return
+end
+
+function shadederror(f, df, x, population, conditioned; kwargs...)
+    s = plot()
+    shadederror!(f, df, x, population, conditioned; kwargs...)
+    return s
+end
+
+function shadederror!(f, df, x, population, conditioned; kwargs...)
+    if isempty(conditioned)
+        shadederror!(f, df, x, population; kwargs...)
+    else
+        by(df,conditioned) do dd
+            shadederror!(f,dd,x,population; kwargs...)
+            return
+        end
+    end
+    return
+end


### PR DESCRIPTION
I've added the shaded error plot (which was trivial to do using ribbon, except ribbon plots are not implemented in all backends, a notable exception being PlotlyJS: [#565](https://github.com/tbreloff/Plots.jl/issues/565) ).

<img width="498" alt="screenshot 2016-11-30 20 08 43" src="https://cloud.githubusercontent.com/assets/6333339/20769206/e08209f2-b738-11e6-8eec-d41ad66bc081.png">

Also, I thought it'd be nicer to be able to plot shaded error bars starting directly from a dataframe, giving as input also the variable corresponding to the x axis, the function corresponding to the analysis of interest (could be a density plot, or a cumulative plot, or plotting some other column y as a fct of x) and the categorical variable corresponding to the "population of interest" across which one should compute the standard error of the mean to see to what extent the analysis is consistent across individuals of the population (this kind of analysis is common in my field). Also, one can split data according to one or more other columns.

Example: compute density plot of magnitude of earthquakes. Shaded-error bar = s.e.m. across stations. Split data by depth of earthquake.

<img width="556" alt="screenshot 2016-11-30 20 08 52" src="https://cloud.githubusercontent.com/assets/6333339/20769335/66a4bd40-b739-11e6-9bba-f6e305266910.png">

This is preliminary work, but if it is of interest I think it could be nice to continue in this direction as follows:

- In the version where the data is conditioned on one or several variables, add possibility of modifying graphical elements according to the value of those variables (label, color, dashed vs full line and other attributes could depend on the value of the conditional variables in a way determined by the user)
- Build a list of reasonable functions f and incorporate them, e.g. density, cdf, hazard, y as function of x (with some nonparametric regression I guess)
- Do the same for scatter plots and bar plots