### PR TITLE
Remove version requirement for DataFrames

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,6 +4,6 @@ Reexport
 Plots 0.10
 StatsBase
 Distributions
-DataFrames 0.0 0.9
+DataFrames
 KernelDensity
 Loess


### PR DESCRIPTION
The change to Nullables is now implemented in DataTables instead