### PR TITLE
Fix groupapply axis for density plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,18 +155,18 @@ using StatPlots
 gr()
 school = RDatasets.dataset("mlmRev","Hsb82");
 grp_error = groupapply(:cumulative, school, :MAch; compute_error = (:across,:School), group = :Sx)
-plot(grp_error, line = :path)
+plot(grp_error, line = :path, legend = :topleft)
 ```
-<img width="494" alt="screenshot 2016-12-19 12 28 27" src="https://cloud.githubusercontent.com/assets/6333339/21313005/316e0f0c-c5e7-11e6-9464-f0921dee3d29.png">
+<img width="494" alt="screenshot 2016-12-19 12 28 27" src="https://user-images.githubusercontent.com/6333339/29280675-1a8df192-8114-11e7-878e-754ecdd9184d.png">
 
 Keywords for loess or kerneldensity can be given to groupapply:
 
 ```julia
-grp_error = groupapply(:density, school, :CSES; bandwidth = 1., compute_error = (:bootstrap,500), group = :Minrty)
+grp_error = groupapply(:density, school, :CSES; bandwidth = 0.2, compute_error = (:bootstrap,500), group = :Minrty)
 plot(grp_error, line = :path)
 ```
 
-<img width="487" alt="screenshot 2017-01-10 18 36 48" src="https://cloud.githubusercontent.com/assets/6333339/21819500/cb788fb8-d763-11e6-89b9-91018f2b9a2a.png">
+<img width="487" alt="screenshot 2017-01-10 18 36 48" src="https://user-images.githubusercontent.com/6333339/29280692-2bc1f97c-8114-11e7-932e-a86156d36cf5.png">
 
 
 The bar plot
@@ -176,4 +176,4 @@ pool!(school, :Sx)
 grp_error = groupapply(school, :Sx, :MAch; compute_error = :across, group = :Minrty)
 plot(grp_error, line = :bar)
 ```
-<img width="489" alt="screenshot 2017-01-10 18 20 51" src="https://cloud.githubusercontent.com/assets/6333339/21819413/7923681e-d763-11e6-907d-c81447b4cc99.png">
+<img width="489" alt="screenshot 2017-01-10 18 20 51" src="https://user-images.githubusercontent.com/6333339/29280710-3998b310-8114-11e7-9a24-a93d5727cc52.png">

--- a/src/groupederror.jl
+++ b/src/groupederror.jl
@@ -62,6 +62,9 @@ function _density(df,xaxis, x)
     return extend_axis(xhist, x, :length, xaxis, 0.)
 end
 
+_density_axis(df, axis_type::Symbol, x; kwargs...) =
+    (axis_type == :discrete) ? get_axis(df[x]) : KernelDensity.kde(df[x]; kwargs...).x
+
 """
     `_cumulative(df, xaxis, x) = ecdf(df[x])(xaxis)`
 
@@ -93,17 +96,18 @@ end
 get_axis(column) = sort!(union(column))
 get_axis(column, npoints::Int64) = linspace(Plots.ignorenan_minimum(column),Plots.ignorenan_maximum(column),npoints)
 
-function get_axis(column, axis_type::Symbol, compute_axis::Symbol)
+function get_axis(df, axis_type::Symbol, compute_axis::Symbol, args...; kwargs...)
     if axis_type == :discrete
-        return get_axis(column)
+        return get_axis(df[args[1]])
     elseif axis_type == :continuous
-        return get_axis(column, 100)
+        return get_axis(df[args[1]], 100)
     else
         error("Unexpected axis_type: only :discrete and :continuous allowed!")
     end
 end
 
-get_axis(column, axis_type::Symbol, compute_axis) = compute_axis(column, axis_type::Symbol)
+get_axis(df, axis_type::Symbol, compute_axis, args...; kwargs...) =
+    compute_axis(df, axis_type, args...; kwargs...)
 
 # f is the function used to analyze dataset: define it as nan when it is not defined,
 # the input is: dataframe used, points chosen on the x axis, x (and maybe y) column labels
@@ -191,15 +195,15 @@ end
 
 """
     get_groupederror(trend,variation, f, df::AbstractDataFrame, axis_type, ce,  args...;
-        compute_axis = :separate, kwargs...)
+        compute_axis = :auto, kwargs...)
 
 Choose shared axis according to `axis_type` (`:continuous` or `:discrete`) then
 compute `get_groupederror`.
 """
 function get_groupederror(trend,variation, f, df::AbstractDataFrame, axis_type, ce,  args...;
-    compute_axis = :separate, kwargs...)
+    compute_axis = :auto, kwargs...)
     # define points on x axis
-    xvalues = get_axis(df[args[1]], axis_type, compute_axis)
+    xvalues = get_axis(df, axis_type, compute_axis, args...; kwargs...)
     return get_groupederror(trend,variation, f, df::AbstractDataFrame, xvalues, ce, args...; kwargs...)
 end
 
@@ -278,6 +282,8 @@ end
 builtin_funcs = Dict(zip([:locreg, :density, :cumulative, :hazard],
     [_locreg, _density, _cumulative, _hazard]))
 
+builtin_axis = Dict(:density => _density_axis)
+
 """
     groupapply(s::Symbol, df, args...; kwargs...)
 
@@ -288,9 +294,11 @@ is equivalent to `groupapply(:locreg, df, args[1], s; kwargs...)`
 function groupapply(s::Symbol, df, args...; kwargs...)
     if s in keys(builtin_funcs)
         analysisfunction = builtin_funcs[s]
-        return groupapply(analysisfunction, df, args...; kwargs...)
+        return groupapply(analysisfunction, df, args...;
+            compute_axis = get(builtin_axis, s, :auto), kwargs...)
     else
-        return groupapply(_locreg, df, args[1], s; kwargs...)
+        return groupapply(_locreg, df, args[1], s;
+            compute_axis = get(builtin_axis, :locreg, :auto), kwargs...)
     end
 end
 


### PR DESCRIPTION
Corrected x axis computation for kernel density plot (it used to have issues in case of distributions who grow steeply at their minimum, e.g. Gamma)

Before:

![before](https://user-images.githubusercontent.com/6333339/29281086-8ae6cc6a-8115-11e7-970d-2625501fce6b.png)

After:

![after](https://user-images.githubusercontent.com/6333339/29281095-934a2636-8115-11e7-8472-241133db2227.png)

