### PR TITLE
Allow specifying :wand bins

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
-julia 0.6-pre
+julia 0.6
 
 Reexport
-Plots 0.12.0
+Plots 0.12.4
 StatsBase
 Distributions
 DataFrames

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -17,7 +17,6 @@ import Loess
 
 export groupapply
 export get_groupederror
-export wand_edges
 export @df
 
 include("df.jl")

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -17,6 +17,7 @@ import Loess
 
 export groupapply
 export get_groupederror
+export wand_edges
 export @df
 
 include("df.jl")

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -34,3 +34,131 @@ Plots.@deps density path
     ()
 end
 Plots.@deps cdensity path
+
+
+
+function linbin(X, gpoints; truncate = true)
+    n, M = length(x), length(gpoints)
+
+    a, b = gpoints[1], gpoints[M]
+    gcnts = zeros(M)
+    delta = (b-a)/(M-1)
+
+    for i in 1:n
+        lxi = ((X[i]-a)/delta) + 1
+        li = floor(Int, lxi)
+        rem = lxi - li
+
+        if 1 <= li < M
+            gcnts[li] += 1-rem
+            gcnts[li+1] += rem
+        end
+
+        if !truncate
+            if lt < 1
+                gcnts[1] += 1
+            end
+
+            if li >= M
+                gcnts[M] += 1
+            end
+        end
+    end
+    gcnts
+end
+
+
+
+function wand_bins(x, scalest = :minim, level = 2, gridsize = 401, range_x = extrema(x), truncate = true)
+
+    level > 5 && error("Level should be between 0 and 5")
+    n = length(x)
+    minx = range_x[1]
+    maxx = range_x[2]
+    gpoints = linspace(minx, maxx, gridsize)
+    gcounts = linbin(x, gpoints, truncate)
+
+    scalest = if scalest == :stdev
+        sqrt(var(x))
+    elseif scalest == :iqr
+        (quantile(x, 3//4) - quantile(x, 1//4))/1.349
+    elseif scalest == :minim
+        min((quantile(x, 3//4) - quantile(x, 1//4))/1.349, sqrt(var(x))
+    else
+        error("scalest must be one of :stdev, :iqr or :minim (default)")
+    end
+
+    scalest == 0 && error("scale estimate is zero for input data")
+    sx = (x .- mean(x))./scalest
+    sa = (minx - mean(x))/scalest
+    sb = (maxx - mean(x))/scalest
+
+    gpoints = linspace(sa, sb, gridsize)
+    gcounts = linbin(sx, gpoints, truncate)
+
+# made it to here with porting
+
+    hpi <- if (level == 0L)
+        (24 * sqrt(pi)/n)^(1/3)
+    else if (level == 1L) {
+        alpha <- (2/(3 * n))^(1/5) * sqrt(2)
+        psi2hat <- bkfe(gcounts, 2L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        (6/(-psi2hat * n))^(1/3)
+    }
+    else if (level == 2L) {
+        alpha <- ((2/(5 * n))^(1/7)) * sqrt(2)
+        psi4hat <- bkfe(gcounts, 4L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (sqrt(2/pi)/(psi4hat * n))^(1/5)
+        psi2hat <- bkfe(gcounts, 2L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        (6/(-psi2hat * n))^(1/3)
+    }
+    else if (level == 3L) {
+        alpha <- ((2/(7 * n))^(1/9)) * sqrt(2)
+        psi6hat <- bkfe(gcounts, 6L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (-3 * sqrt(2/pi)/(psi6hat * n))^(1/7)
+        psi4hat <- bkfe(gcounts, 4L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (sqrt(2/pi)/(psi4hat * n))^(1/5)
+        psi2hat <- bkfe(gcounts, 2L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        (6/(-psi2hat * n))^(1/3)
+    }
+    else if (level == 4L) {
+        alpha <- ((2/(9 * n))^(1/11)) * sqrt(2)
+        psi8hat <- bkfe(gcounts, 8L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (15 * sqrt(2/pi)/(psi8hat * n))^(1/9)
+        psi6hat <- bkfe(gcounts, 6L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (-3 * sqrt(2/pi)/(psi6hat * n))^(1/7)
+        psi4hat <- bkfe(gcounts, 4L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (sqrt(2/pi)/(psi4hat * n))^(1/5)
+        psi2hat <- bkfe(gcounts, 2L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        (6/(-psi2hat * n))^(1/3)
+    }
+    else if (level == 5L) {
+        alpha <- ((2/(11 * n))^(1/13)) * sqrt(2)
+        psi10hat <- bkfe(gcounts, 10L, alpha, range.x = c(sa,
+            sb), binned = TRUE)
+        alpha <- (-105 * sqrt(2/pi)/(psi10hat * n))^(1/11)
+        psi8hat <- bkfe(gcounts, 8L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (15 * sqrt(2/pi)/(psi8hat * n))^(1/9)
+        psi6hat <- bkfe(gcounts, 6L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (-3 * sqrt(2/pi)/(psi6hat * n))^(1/7)
+        psi4hat <- bkfe(gcounts, 4L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        alpha <- (sqrt(2/pi)/(psi4hat * n))^(1/5)
+        psi2hat <- bkfe(gcounts, 2L, alpha, range.x = c(sa, sb),
+            binned = TRUE)
+        (6/(-psi2hat * n))^(1/3)
+    }
+    scalest * hpi
+end

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -41,7 +41,7 @@ Plots.@deps cdensity path
 # Ported from R code located here https://github.com/cran/KernSmooth/tree/master/R
 
 "Returns optimal histogram edge positions in accordance to Wand (1995)'s criterion'"
-wand_edges(x, args...) = (binwidth = wand_bins(x, args...); minimum(x)-binwidth:binwidth:maximum(x)+binwidth)
+Plots.wand_edges(x::AbstractVector, args...) = (binwidth = wand_bins(x, args...); minimum(x)-binwidth:binwidth:maximum(x)+binwidth)
 
 "Returns optimal histogram bin widths in accordance to Wand (1995)'s criterion'"
 function wand_bins(x, scalest = :minim, gridsize = 401, range_x = extrema(x), trun = true)

--- a/src/hist.jl
+++ b/src/hist.jl
@@ -41,7 +41,7 @@ Plots.@deps cdensity path
 # Ported from R code located here https://github.com/cran/KernSmooth/tree/master/R
 
 function linbin(X, gpoints; trun = true)
-    n, M = length(x), length(gpoints)
+    n, M = length(X), length(gpoints)
 
     a, b = gpoints[1], gpoints[M]
     gcnts = zeros(M)
@@ -93,12 +93,12 @@ function bkfe(gcounts, drv, bandwidth, range_x)
     arg = lvec .* delta/h
 
     kappam = pdf(Normal(),arg)/(h^(drv+1))
-    hmold0 = 1
+    hmold0, hmnew = ones(length(arg)), ones(length(arg))
     hmold1 = arg
-    hmnew = 1
+
     if drv >= 2
         for i in (2:drv)
-            hmnew = arg .* hmold1 .- (i-1)*hmold0
+            hmnew = arg .* hmold1 .- (i-1) .* hmold0
             hmold0 = hmold1       # Compute mth degree Hermite polynomial
             hmold1 = hmnew        # by recurrence.
         end


### PR DESCRIPTION
Depends on https://github.com/JuliaPlots/Plots.jl/pull/1053

This allows specifying binning using the data-based criterion of Wand, M.P. (1997) Data-Based Choice of Histogram Bin Width. The American Statistician, 51, 59-64. This belongs to a different, more modern class of histogram implementations where the correct bin size number is not only selected based on sample size, but also based on the shape of the distribution. Essentially it creates a kernel density and then finds the bin positions that minimizes the discrepancy between the histogram and the density function.

The code is a port of the `dpih` and associated functions found here: https://github.com/cran/KernSmooth/tree/master/R - the original license is "Unlimited" and I have the author's (Wand himself) permission to use it.

The bins are different from what we otherwise use in Plots as the bin edges do not align nicely with integer multipla of 1, 2 and 5. I wrote to Wand to ask him, and he insisted that was the most statistically valid in his view.

Comparisons using a skewed mixture distribution with 60, 300, 3000 and 30000 samples:
```julia
using Distributions, Plots
m = MixtureModel([Normal(),Normal(3, 2//3), Normal(2, 1//3)])
samples = (rand(m,x) for x in [60, 300, 3000, 30000])

gr(size = (1200, 1000), legend = false)
hists = [histogram(x, title = y, bins = y) for x in samples for y in [:auto, :scott, :wand]];
plot(hists..., layout = (4,3))
```
![skaermbillede 2017-08-29 kl 14 34 09](https://user-images.githubusercontent.com/8429802/29821184-4c33b0d8-8cc7-11e7-91b2-f03c4f6bcefc.png)


