### PR TITLE
WIP: add compatibility to a general table type and remove DataFrames dependency

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ DataFrames
 KernelDensity
 Loess
 IterableTables 0.5.0
+TableTraitsUtils 0.1.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,3 +7,4 @@ Distributions
 DataFrames
 KernelDensity
 Loess
+IterableTables

--- a/REQUIRE
+++ b/REQUIRE
@@ -7,4 +7,4 @@ Distributions
 DataFrames
 KernelDensity
 Loess
-IterableTables
+IterableTables 0.5.0

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -8,7 +8,8 @@ using StatsBase
 using Distributions
 using DataFrames
 using IterableTables
-using DataValues
+import DataValues: DataValue
+import TableTraits: column_types, column_names
 
 import KernelDensity
 import Loess

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -7,6 +7,8 @@ import Plots: _cycle
 using StatsBase
 using Distributions
 using DataFrames
+using IterableTables
+using DataValues
 
 import KernelDensity
 import Loess

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -7,9 +7,10 @@ import Plots: _cycle
 using StatsBase
 using Distributions
 using DataFrames
-using IterableTables
+import IterableTables
 import DataValues: DataValue
-import TableTraits: column_types, column_names
+import TableTraits: column_types, column_names, getiterator, isiterabletable
+import TableTraitsUtils: create_columns_from_iterabletable
 
 import KernelDensity
 import Loess

--- a/src/df.jl
+++ b/src/df.jl
@@ -55,15 +55,7 @@ function select_column(df, s)
 end
 
 convert_missing(el) = el
-
-function convert_missing(el::DataValue{T}) where T
-    try
-        get(el)
-    catch
-        error("Missing data of type $T is not supported")
-    end
-end
-
+convert_missing(el::DataValue{T}) where {T} = get(el, error("Missing data of type $T is not supported"))
 convert_missing(el::DataValue{<:AbstractString}) = get(el, "")
 convert_missing(el::DataValue{Symbol}) = get(el, Symbol())
 convert_missing(el::DataValue{<:Real}) = get(convert(DataValue{Float64}, el), NaN)

--- a/src/df.jl
+++ b/src/df.jl
@@ -49,21 +49,21 @@ function select_column(df, s)
     v = try
             [getfield(i, s) for i in getiterator(df)]
         catch
-            s
+            return s
         end
-    return convert_column(v)
+    return convert_missing.(v)
 end
 
-convert_column(col) = col
+convert_missing(el) = el
 
-function convert_column(col::AbstractArray{T}) where T<:DataValue
+function convert_missing(el::DataValue{T}) where T
     try
-        get.(col)
+        get(el)
     catch
         error("Missing data of type $T is not supported")
     end
 end
 
-convert_column(col::AbstractArray{DataValue{<:AbstractString}}) = get.(col, "")
-convert_column(col::AbstractArray{DataValue{Symbol}}) = get.(col, Symbol())
-convert_column(col::AbstractDataArray{DataValue{<:Real}}) = get.(convert.(DataValue{Float64}, col), NaN)
+convert_missing(el::DataValue{<:AbstractString}) = get(el, "")
+convert_missing(el::DataValue{Symbol}) = get(el, Symbol())
+convert_missing(el::DataValue{<:Real}) = get(convert(DataValue{Float64}, el), NaN)

--- a/src/df.jl
+++ b/src/df.jl
@@ -48,7 +48,7 @@ not_kw(x::Expr) = !(x.head in [:kw, :parameters])
 _arg2string(d, x) = stringify(x)
 function _arg2string(d, x::Expr)
     if x.head == :call && x.args[1] == :cols
-        return :(reshape([(DataFrames.names($d)[i]) for i in $(x.args[2])], 1, :))
+        return :(reshape([StatPlots.compute_name($d, i) for i in $(x.args[2])], 1, :))
     elseif x.head == :call && x.args[1] == :hcat
         return hcat(stringify.(x.args[2:end])...)
     elseif x.head == :hcat
@@ -60,7 +60,7 @@ end
 
 stringify(x) = filter(t -> t != ':', string(x))
 
-#compute_all(d, s...) = [StatPlots.select_column(d, ss) for ss in s]
+compute_name(df, i) = column_names(IterableTables.getiterator(df))[i]
 
 function compute_all(df, syms...)
     iter = IterableTables.getiterator(df)

--- a/src/df.jl
+++ b/src/df.jl
@@ -46,12 +46,9 @@ end
 stringify(x) = filter(t -> t != ':', string(x))
 
 function select_column(df, s)
-    v = try
-            [getfield(i, s) for i in getiterator(df)]
-        catch
-            return s
-        end
-    return convert_missing.(v)
+    iter = IterableTables.getiterator(df)
+    isa(s, Symbol) && !(s in column_names(iter)) && return s
+    [convert_missing(getfield(i, s)) for i in iter]
 end
 
 convert_missing(el) = el

--- a/src/df.jl
+++ b/src/df.jl
@@ -46,12 +46,12 @@ end
 stringify(x) = filter(t -> t != ':', string(x))
 
 function select_column(df, s)
-    iterator = getiterator(df)
-    if s in fieldnames(next(iterator, 1)[1]) || isa(s, Integer)
-        return convert_column([getfield(i, s) for i in iterator])
-    else
-        return s
-    end
+    v = try
+            [getfield(i, s) for i in getiterator(df)]
+        catch
+            s
+        end
+    return convert_column(v)
 end
 
 convert_column(col) = col


### PR DESCRIPTION
This is work in progress to pass from a DataFrames based implementation of `@df` to a IterableTables base implementation. The following commands now give the desired plots (should work for everything that is supported by IterableTables):

```julia
using IterableTables, DataFrames, IndexedTables, RDatasets, CSV, StatPlots
iris = dataset("datasets","iris")
writetable("/tmp/iris.csv", iris)
@df CSV.Source("/tmp/iris.csv") scatter(:SepalLength, :SepalWidth)
iris[:SepalLength][2] = NA
iris_table = IndexedTable(iris)
@df iris_table scatter(:SepalLength, :SepalWidth)
```

The implementation of the `@df` macro no longer requires a DataFrames dependency. It works in the following way: IterableTables provides a `getiterator` which, from a table, creates a row based iterator which spits out every row as a named tuple. What I do here is to replace every symbol in the plot call with a new variable. Then the macro generates 2 commands: one to assign to the new variables the respective columns (using the function `StatPlots.compute_all`) and the other to do the  plot:

```julia
julia> @macroexpand @df iris_table scatter(:SepalLength, :SepalWidth)
quote 
    (##SepalLength#730, ##SepalWidth#731) = StatPlots.compute_all(iris_table, :SepalLength, :SepalWidth)
    scatter(##SepalLength#730, ##SepalWidth#731)
end
```

The advantage of doing all variables at once (and knowing exactly which they are) is twofold:
- As they are all replaced together, we can see which rows have unsupported missing data and potentially remove them with a warning
- the `getiterator` has to be iterated only once, which is better especially in the case of CSV or remote databases

I still need to polish a bit and further optimize `StatPlots.compute_all` but I wanted to check if this is a direction we're happy to take.