### PR TITLE
Explicitly require tabletraits and Datavalues

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -9,3 +9,5 @@ KernelDensity
 Loess
 IterableTables 0.5.0
 TableTraitsUtils 0.1.0
+TableTraits
+DataValues


### PR DESCRIPTION
These are already imported by IterableTables, so it's a matter of design to import from them directly - see the discussion here: https://github.com/JuliaPlots/StatPlots.jl/pull/82#issuecomment-326453137