### PR TITLE
fix boxplot behavior when only y values are provided

### DIFF
--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -9,10 +9,6 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     if typeof(x) <: UnitRange
         x = [getindex(x, d[:series_plotindex])]
     end
-    # x values need to be categories
-    if !(typeof(x) in (Array{String,1}, Array{Symbol,1}))
-        x = string.(x)
-    end
     xsegs, ysegs = Segments(), Segments()
     glabels = sort(collect(unique(x)))
     warning = false

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -10,7 +10,7 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
         x = [getindex(x, d[:series_plotindex])]
     end
     # x values need to be categories
-    if !(typeof(x) in (String, Symbol))
+    if !(typeof(x) in (Array{String,1}, Array{Symbol,1}))
         x = string.(x)
     end
     xsegs, ysegs = Segments(), Segments()

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -5,6 +5,14 @@
 notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
 
 @recipe function f(::Type{Val{:boxplot}}, x, y, z; notch=false, range=1.5, outliers=true, whisker_width=:match)
+    # if only y is provided, then x will be UnitRange 1:length(y)
+    if typeof(x) <: UnitRange
+        x = [getindex(x, d[:series_plotindex])]
+    end
+    # x values need to be categories
+    if !(typeof(x) in (String, Symbol))
+        x = string.(x)
+    end
     xsegs, ysegs = Segments(), Segments()
     glabels = sort(collect(unique(x)))
     warning = false

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -16,6 +16,10 @@ end
 
 
 @recipe function f(::Type{Val{:violin}}, x, y, z; trim=true, side=:both)
+    # if only y is provided, then x will be UnitRange 1:length(y)
+    if typeof(x) <: UnitRange
+        x = [getindex(x, d[:series_plotindex])]
+    end
     xsegs, ysegs = Segments(), Segments()
     glabels = sort(collect(unique(x)))
     bw = d[:bar_width]


### PR DESCRIPTION
This fixes the behavior of `boxplot()` when user only provides y values. Related to discussion in #56

I hope it's not too much of a hack.

Some quick tests:
```
boxplot(rand(10))

boxplot(rand(10,2))

boxplot(["a" "b"], rand(10,2))

boxplot([:c :d], rand(10,2))

boxplot(3:4, rand(10,2))

boxplot([3 4], rand(10,2))

boxplot([0.5 4], rand(10,2))

boxplot(rand(["a", "b"], 20), rand(20))

boxplot([rand(["a", "b"], 20) rand(["c", "d"], 20)], rand(20,2))

boxplot([rand([:a, :b], 20) rand([:c, :d], 20)], rand(20,2))
```