### PR TITLE
fixes #94 correctly catch datavalue error

### DIFF
--- a/src/df.jl
+++ b/src/df.jl
@@ -74,7 +74,7 @@ function extract_columns_from_iterabletable(df, syms...)
 end
 
 convert_missing(el) = el
-convert_missing(el::DataValue{T}) where {T} = get(el, error("Missing data of type $T is not supported"))
+convert_missing(el::DataValue{T}) where {T} = isnull(el) ? error("Missing data of type $T is not supported") : el.value
 convert_missing(el::DataValue{<:AbstractString}) = get(el, "")
 convert_missing(el::DataValue{Symbol}) = get(el, Symbol())
 convert_missing(el::DataValue{<:Real}) = get(convert(DataValue{Float64}, el), NaN)


### PR DESCRIPTION
Now

```julia
using StatPlots, DataFrames

df_any = DataFrame(Any, 0, 1)

for i in 1:10
    push!(df_any, rand())
end

@df df_any plot(:x1)
```

works, as it should, and it gives the correct error message if there is missing data we don't know how to handle:

```julia
df_any[2, :x1] = NA
@df df_any plot(:x1)    # Error: "Missing data of type Any is not supported"
```