### PR TITLE
curry @df macro

### DIFF
--- a/src/df.jl
+++ b/src/df.jl
@@ -17,6 +17,16 @@ macro df(d, x)
     esc(Expr(:block, compute_vars, plot_call))
 end
 
+"""
+    `@df x`
+
+Curried version of `@df d x`. Outputs an anonymous function `d -> @df d x`.
+"""
+macro df(x)
+    i = gensym()
+    :($i -> @df($i, $x))
+end
+
 parse_iterabletable_call!(d, x, syms, vars) = x
 
 function parse_iterabletable_call!(d, x::Expr, syms, vars)


### PR DESCRIPTION
Allows to combine our macro with the new Query.jl pipeline syntax (see [here](https://github.com/davidanthoff/Query.jl/blob/master/docs/src/experimental.md)):

```julia
using Query, DataFrames
df = DataFrame(a = 1:10, b = 10*rand(10), c = 10 * rand(10))
df |>
    @where(_.a > 5) |>
    @select({_.b, d = _.c-10}) |>
    @df scatter(:b, :d)
```