### PR TITLE
Restore original corrplot ticks

### DIFF
--- a/src/corrplot.jl
+++ b/src/corrplot.jl
@@ -27,7 +27,7 @@ end
     indices = reshape(1:n^2, n, n)'
     title = get(plotattributes,:title,"")
     title := ""
-    ticks --> false
+    # ticks --> false
 
     # histograms on the diagonal
     for i=1:n
@@ -35,6 +35,8 @@ end
             seriestype := :histogram
             subplot := indices[i,i]
             grid := false
+            xformatter --> ((i == n) ? :auto : (x -> ""))
+            yformatter --> ((i == 1) ? :auto : (y -> ""))
             update_ticks_guides(plotattributes, labs, i, i, n)
             view(mat,:,i)
         end
@@ -56,6 +58,8 @@ end
                     markercolor := grad[0.5 + 0.5C[i,j]]
                     smooth := true
                     markerstrokewidth --> 0
+                    xformatter --> ((i == n) ? :auto : (x -> ""))
+                    yformatter --> ((j == 1) ? :auto : (y -> ""))
                     vj, vi
                 end
             else
@@ -65,6 +69,8 @@ end
                     if title != "" && i == 1 && j == div(n,2)+1
                         title := title
                     end
+                    xformatter --> ((i == n) ? :auto : (x -> ""))
+                    yformatter --> ((j == 1) ? :auto : (y -> ""))
                     vj, vi
                 end
             end

--- a/src/corrplot.jl
+++ b/src/corrplot.jl
@@ -27,7 +27,6 @@ end
     indices = reshape(1:n^2, n, n)'
     title = get(plotattributes,:title,"")
     title := ""
-    # ticks --> false
 
     # histograms on the diagonal
     for i=1:n


### PR DESCRIPTION
cf https://github.com/JuliaPlots/StatPlots.jl/issues/78#issuecomment-347658317

```julia
using StatPlots
M = randn(1000,4)
M[:,2] += 0.8sqrt.(abs.(M[:,1])) - 0.5M[:,3] + 5
M[:,3] -= 0.7M[:,1].^2 + 2
```

The original behavior with working grid lines as default:
```julia
corrplot(M, label = ["x$i" for i=1:4])
```
![corrplot](https://user-images.githubusercontent.com/16589944/33368401-e8fb1ace-d4f1-11e7-85d9-8ecb488666a7.png)

Without ticks can still be easily achieved:
```julia
corrplot(M, label = ["x$i" for i=1:4], ticks = false)
```
![corrplot_false](https://user-images.githubusercontent.com/16589944/33368424-f4e437bc-d4f1-11e7-9d0d-555b42172475.png)

This is just a suggestion ... Otherwise, as @mauro3 pointed out it is very hard to get the ticks back only on the left and bottom plots, like it was before #81.