### PR TITLE
enable tick labels in last row of cornerplot (fix #114)

### DIFF
--- a/src/cornerplot.jl
+++ b/src/cornerplot.jl
@@ -44,7 +44,8 @@
     linecolor --> Plots.fg_color(plotattributes)
     grid      --> true
     ticks     := nothing
-    formatter := v->""
+    xformatter := x -> ""
+    yformatter := y -> ""
     link      := :both
     grad = cgrad(get(plotattributes, :markercolor, cgrad()))
 


### PR DESCRIPTION
I'm still not entirely sure, why the original implementation did not work (cf #114). This however fixes the problem:
![cornerplot](https://user-images.githubusercontent.com/16589944/33487585-f7d499d6-d6ad-11e7-9180-fd98e3ca052c.png)
