### PR TITLE
added labelling to df

### DIFF
--- a/src/df.jl
+++ b/src/df.jl
@@ -42,13 +42,14 @@ end
 parse_iterabletable_call!(d, x, syms, vars) = x
 
 function parse_iterabletable_call!(d, x::Expr, syms, vars)
-    if x.head == :quote
+    if x.head == :. && length(x.args) == 2
+        isa(x.args[2], Expr) && (x.args[2].head == :quote) && return x
+    elseif x.head == :quote
         new_var = gensym(x.args[1])
         push!(syms, x)
         push!(vars, new_var)
         return new_var
-    end
-    if x.head == :call
+    elseif x.head == :call
         x.args[1] == :^ && length(x.args) == 2 && return x.args[2]
         if x.args[1] == :cols
             range = eval(x.args[2])


### PR DESCRIPTION
Now the `@df` macro also fills in the legend when there are multiple series:

```julia
df = DataFrame(a = 1:10, b = 10*rand(10), c = 10 * rand(10))
@df df plot(:a, [sqrt.(:b) :c])
```
![label](https://user-images.githubusercontent.com/6333339/33529030-73300a9c-d862-11e7-81ad-a2609d47d17f.png)

```julia
@df iris corrplot(cols(1:4))
```

![corrplot](https://user-images.githubusercontent.com/6333339/33529031-798b5cca-d862-11e7-9046-6386dad50158.png)

I didn't add automatic labelling of axis so far because:

- We don't normally write anything on the axis (whereas we add `y1, y2, ...` on the legend)
- It's hard to infer what is on what axis when there only is one variable from the function call. For example `@df df scatter(:a)` should label the `y` axis whereas `@df df density(:a)` should label the `x` axis

I'm wondering whether some of it could also be added in Plots with a `@label` macro that would add the legend to a plot (see [#1072](https://github.com/JuliaPlots/Plots.jl/issues/1072)).