### PR TITLE
Improve cols, fixes #119

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,21 @@ using DataFrames, IndexedTables
 df = DataFrame(a = 1:10, b = 10*rand(10), c = 10 * rand(10))
 @df df plot(:a, [:b :c], colour = [:red :blue])
 @df df scatter(:a, :b, markersize = 4 * log.(:c + 0.1))
-t = IndexedTable(Columns(a = collect(1:10)), Columns(b = rand(10)))
+t = table(1:10, rand(10), names = [:a, :b]) # IndexedTable
 @df t scatter(2 * :b)
+```
+
+Inside a `@df` macro call, the `cols` utility function can be used to refer to a range of columns:
+
+```julia
+@df df plot(:a, cols(2:3), colour = [:red :blue])
+```
+
+or to refer to a column whose symbol is represented by a variable:
+
+```julia
+s = :b
+@df df plot(:a, cols(s))
 ```
 
 In case of ambiguity, symbols not referring to `DataFrame` columns must be escaped by `^()`:
@@ -41,13 +54,13 @@ df[:red] = rand(10)
 @df df plot(:a, [:b :c], colour = ^([:red :blue]))
 ```
 
-The `@df` macro plays nicely with the new syntax of the [Query.jl](https://github.com/davidanthoff/Query.jl) data manipulation package (v0.7 and above), in that a plot command can be added at the end of a query pipeline, without having to explicitly collect the outcome of the query first:
+The `@df` macro plays nicely with the new syntax of the [Query.jl](https://github.com/davidanthoff/Query.jl) data manipulation package (v0.8 and above), in that a plot command can be added at the end of a query pipeline, without having to explicitly collect the outcome of the query first:
 
 ```julia
 using Query, StatPlots
 df |>
-    @where(_.a > 5) |>
-    @select({_.b, d = _.c-10}) |>
+    @filter(_.a > 5) |>
+    @map({_.b, d = _.c-10}) |>
     @df scatter(:b, :d)
 ```
 

--- a/src/df.jl
+++ b/src/df.jl
@@ -20,9 +20,9 @@ macro df(d, x)
         plot_call = parse_iterabletable_call!(d, x, syms, vars)
         compute_vars = Expr(:(=), Expr(:tuple, vars...),
             Expr(:call, :(StatPlots.extract_columns_from_iterabletable), d, syms...))
-        argnames = _argnames(d, x)
-        i = findlast(t -> isa(t, Expr) || isa(t, AbstractArray), argnames)
-        (i == 0) || insert_kw!(plot_call, :label, argnames[i])	
+        #argnames = _argnames(d, x)
+        #i = findlast(t -> isa(t, Expr) || isa(t, AbstractArray), argnames)
+        #(i == 0) || insert_kw!(plot_call, :label, argnames[i])	
         return esc(Expr(:block, compute_vars, plot_call))
     else
         error("Second argument can only be a block or function call")
@@ -52,11 +52,11 @@ function parse_iterabletable_call!(d, x::Expr, syms, vars)
     elseif x.head == :call
         x.args[1] == :^ && length(x.args) == 2 && return x.args[2]
         if x.args[1] == :cols
-            range = eval(x.args[2])
-            new_vars = gensym.(string.(range))
-            append!(syms, range)
-            append!(vars, new_vars)
-            return Expr(:hcat, new_vars...)
+            range = x.args[2]
+            new_vars = gensym("range")
+            push!(syms, range)
+            push!(vars, new_vars)
+            return new_vars
         end
     end
     return Expr(x.head, (parse_iterabletable_call!(d, arg, syms, vars) for arg in x.args)...)
@@ -91,14 +91,24 @@ stringify(x) = filter(t -> t != ':', string(x))
 
 compute_name(df, i) = column_names(getiterator(df))[i]
 
+get_col_from_dict(s::Int, col_dict, name2index) = col_dict[s]
+get_col_from_dict(s::Symbol, col_dict, name2index) = 
+    haskey(name2index, s) ? col_dict[name2index[s]] : s
+
+get_col_from_dict(s, col_dict, name2index) = 
+    hcat(get_col_from_dict.(s, col_dict, name2index)...)
+
 function extract_columns_from_iterabletable(df, syms...)
     isiterabletable(df) || error("Only iterable tables are supported")
     iter = getiterator(df)
     name2index = Dict(zip(column_names(iter), 1:length(column_names(iter))))
-    col_index = [isa(s, Integer) ? s : get(name2index, s, 0) for s in syms]
-    cols = convert(Array{Any}, collect(syms))
-    cols[col_index .!= 0] = create_columns_from_iterabletable(df, filter(t -> t != 0, col_index))[1]
-    return Tuple(convert_missing.(t) for t in cols)
+
+    col_indices = union(Iterators.filter(t -> t != 0, 
+        (isa(s, Integer) ? s : get(name2index, s, 0) for s in vcat(syms...))))
+    col_values = create_columns_from_iterabletable(df, col_indices)[1]
+    col_dict = Dict(zip(col_indices, [convert_missing.(t) for t in col_values]))
+
+    return Tuple(get_col_from_dict(s, col_dict, name2index) for s in syms)
 end
 
 convert_missing(el) = el

--- a/src/df.jl
+++ b/src/df.jl
@@ -21,7 +21,12 @@ macro df(d, x)
         compute_vars = Expr(:(=), Expr(:tuple, vars...),
             Expr(:call, :(StatPlots.extract_columns_from_iterabletable), d, syms...))
         argnames = _argnames(d, x)
-        label_plot_call = Expr(:call, :(StatPlots.add_label), argnames, plot_call.args...) 
+        if (length(plot_call.args) >= 2) && isa(plot_call.args[2], Expr) && (plot_call.args[2].head == :parameters)
+            label_plot_call = Expr(:call, :(StatPlots.add_label), plot_call.args[2], argnames,
+                plot_call.args[1], plot_call.args[3:end]...)
+        else
+            label_plot_call = Expr(:call, :(StatPlots.add_label), argnames, plot_call.args...)
+        end
         return esc(Expr(:block, compute_vars, label_plot_call))
     else
         error("Second argument can only be a block or function call")


### PR DESCRIPTION
This allows for a more powerful use of `cols`:  now it can take any variable that corresponds to a symbol, an integer or an AbstractVector of symbols or integers. If it contains an AbstractVector, the resulting columns will be concatenated horizontally and the names of those columns will be added to the legend.

Examples:

```julia
using StatPlots, DataFrames
smallDf = DataFrame(A = rand(10),B=rand(10))
x = :A
@df smallDf histogram(cols(x))
@df smallDf histogram(cols(1))
xy = [:A, :B]
@df smallDf corrplot(cols(xy))
@df smallDf corrplot(cols(1:2))
```

This implementation is slightly less concise but has the advantage of not resorting to `eval`