### PR TITLE
drop LOESS dep

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,7 +5,6 @@ Plots 0.14
 StatsBase
 Distributions
 KernelDensity
-Loess
 IterableTables 0.5.0
 TableTraitsUtils 0.1.0
 TableTraits

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -13,7 +13,6 @@ import TableTraits: column_types, column_names, getiterator, isiterabletable
 import TableTraitsUtils: create_columns_from_iterabletable
 
 import KernelDensity
-import Loess
 @recipe f(k::KernelDensity.UnivariateKDE) = k.x, k.density
 @recipe f(k::KernelDensity.BivariateKDE) = k.x, k.y, k.density.'
 


### PR DESCRIPTION
Seems to no longer be necessary – probably left behind when GroupedErrors got split off.