### PR TITLE
improvements to @df and cols plus news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,13 @@
 
 ## 0.7 current version
 
+### 0.7.1
+
+- remove Loess dependency
+- fix hygien macro issue in `@df`
+- add curly bracket syntax for automatic naming of groups
+- add `cols()` to select all columns
+
 ### 0.7.0
 - remove DataFrames dependency
 - improve tick handling in correlation plots

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ s = :b
 @df df plot(:a, cols(s))
 ```
 
+`cols()` will refer to all columns of the data table.
+
 In case of ambiguity, symbols not referring to `DataFrame` columns must be escaped by `^()`:
 ```julia
 df[:red] = rand(10)
@@ -79,6 +81,8 @@ To group by more than one column, use a tuple of symbols:
 ```
 
 ![grouped](https://user-images.githubusercontent.com/6333339/35101563-eacf9be4-fc57-11e7-88d3-db5bb47b08ac.png)
+
+To name the legend entries with custom or automatic names (i.e. `Sex = Male, Sector = Public`) use the curly bracket syntax `group = {Sex = :Sx, :Sector}`. Entries with `=` get the custom name you give, whereas entries without `=` take the name of the column.
 
 ---
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -9,3 +9,4 @@ IterableTables 0.5.0
 TableTraitsUtils 0.1.0
 TableTraits
 DataValues
+NamedTuples

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -11,6 +11,7 @@ import IterableTables
 import DataValues: DataValue
 import TableTraits: column_types, column_names, getiterator, isiterabletable
 import TableTraitsUtils: create_columns_from_iterabletable
+import NamedTuples
 
 import KernelDensity
 @recipe f(k::KernelDensity.UnivariateKDE) = k.x, k.density

--- a/src/df.jl
+++ b/src/df.jl
@@ -60,6 +60,10 @@ function parse_iterabletable_call!(d, x::Expr, syms, vars)
     elseif x.head == :call
         x.args[1] == :^ && length(x.args) == 2 && return x.args[2]
         if x.args[1] == :cols
+            if length(x.args) == 1
+                push!(x.args, :(StatPlots.column_names(StatPlots.getiterator(df))))
+                return parse_iterabletable_call!(d, x, syms, vars)
+            end
             range = x.args[2]
             new_vars = gensym("range")
             push!(syms, range)


### PR DESCRIPTION
Added curly bracket syntax in `@df` grouping for automated column naming in the legend, added `cols()` to select all columns and added missing news entries.