### PR TITLE
fix title_location for corrplot (fix #141)

### DIFF
--- a/src/corrplot.jl
+++ b/src/corrplot.jl
@@ -26,11 +26,15 @@ end
     grad = cgrad(get(plotattributes, :markercolor, cgrad()))
     indices = reshape(1:n^2, n, n)'
     title = get(plotattributes,:title,"")
+    title_location = get(plotattributes, :title_location, :center)
     title := ""
 
     # histograms on the diagonal
     for i=1:n
         @series begin
+            if title != "" && title_location == :left && i == 1
+                title := title
+            end
             seriestype := :histogram
             subplot := indices[i,i]
             grid := false
@@ -65,7 +69,7 @@ end
                 #above diag... hist2d
                 @series begin
                     seriestype := get(plotattributes, :seriestype, :histogram2d)
-                    if title != "" && i == 1 && j == div(n,2)+1
+                    if title != "" && i == 1 && ((title_location == :center && j == div(n,2)+1) || (title_location == :right && j == n))
                         title := title
                     end
                     xformatter --> ((i == n) ? :auto : (x -> ""))

--- a/src/corrplot.jl
+++ b/src/corrplot.jl
@@ -70,6 +70,9 @@ end
                 @series begin
                     seriestype := get(plotattributes, :seriestype, :histogram2d)
                     if title != "" && i == 1 && ((title_location == :center && j == div(n,2)+1) || (title_location == :right && j == n))
+                        if iseven(n)
+                            title_location := :left
+                        end
                         title := title
                     end
                     xformatter --> ((i == n) ? :auto : (x -> ""))


### PR DESCRIPTION
```julia
using StatPlots
corrplot(randn(100,4),title="(A)",title_loc=:left)
corrplot(randn(100,4),title="(A)",title_loc=:right)
corrplot(randn(100,4),title="(A)",title_loc=:center)
```

![corrplot_left](https://user-images.githubusercontent.com/16589944/38997326-80cfb1c4-43ed-11e8-9a61-31241df01b06.png)

![corrplot_right](https://user-images.githubusercontent.com/16589944/38997342-88e8be1e-43ed-11e8-8512-4300373ac354.png)

![corrplot_center](https://user-images.githubusercontent.com/16589944/38997358-8e3c05ec-43ed-11e8-8045-0b63a3f8f328.png)
