### PR TITLE
Add interactive GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ The old syntax, passing the `DataFrame` as the first argument to the `plot` call
 
 ---
 
+## Visualizing a table interactively
+
+An experimental GUI based on Interact package is available to create plots from a table interactively, using any of the recipes defined below. This small app can be deployed in a Jupyter lab / notebook, Juno plot pane, a Blink window or in the browser, see [here](https://juliagizmos.github.io/Interact.jl/latest/deploying.html) for instructions.
+
+Note: the GUI is experimental and requires the unreleased version of Interact.
+
+```julia
+import RDatasets
+iris = RDatasets.dataset("datasets", "iris")
+using StatPlots, Interact
+interactstats(iris)
+```
+
+![interactstats](https://user-images.githubusercontent.com/6333339/43359702-abd82d74-929e-11e8-8fc9-b589287f1c23.png)
+
+
 ## marginalhist with DataFrames
 
 ```julia
@@ -238,8 +254,8 @@ The `group` syntax is also possible in combination with `groupedbar`:
 ctg = repeat(["Category 1", "Category 2"], inner = 5)
 nam = repeat("G" .* string.(1:5), outer = 2)
 
-groupedbar(nam, rand(5, 2), group = ctg, xlabel = "Groups", ylabel = "Scores", 
-        title = "Scores by group and category", bar_width = 0.67, 
+groupedbar(nam, rand(5, 2), group = ctg, xlabel = "Groups", ylabel = "Scores",
+        title = "Scores by group and category", bar_width = 0.67,
         lw = 0, framestyle = :box)
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,11 @@ The old syntax, passing the `DataFrame` as the first argument to the `plot` call
 
 An experimental GUI based on Interact package is available to create plots from a table interactively, using any of the recipes defined below. This small app can be deployed in a Jupyter lab / notebook, Juno plot pane, a Blink window or in the browser, see [here](https://juliagizmos.github.io/Interact.jl/latest/deploying.html) for instructions.
 
-Note: the GUI is experimental and requires the unreleased version of Interact.
-
 ```julia
 import RDatasets
 iris = RDatasets.dataset("datasets", "iris")
-using StatPlots, Interact
-interactstats(iris)
+using StatPlots, InteractBulma
+dataviewer(iris)
 ```
 
 ![interactstats](https://user-images.githubusercontent.com/6333339/43359702-abd82d74-929e-11e8-8fc9-b589287f1c23.png)

--- a/REQUIRE
+++ b/REQUIRE
@@ -10,5 +10,6 @@ TableTraitsUtils 0.1.0
 TableTraits
 DataValues
 Widgets
+Observables
 NamedTuples
 Clustering

--- a/REQUIRE
+++ b/REQUIRE
@@ -11,5 +11,6 @@ TableTraits
 DataValues
 Widgets
 Observables
+DataStructures
 NamedTuples
 Clustering

--- a/REQUIRE
+++ b/REQUIRE
@@ -9,5 +9,6 @@ IterableTables 0.5.0
 TableTraitsUtils 0.1.0
 TableTraits
 DataValues
+Widgets
 NamedTuples
 Clustering

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -13,6 +13,7 @@ import TableTraits: column_types, column_names, getiterator, isiterabletable
 import TableTraitsUtils: create_columns_from_iterabletable
 using Widgets, Observables
 import Widgets: @nodeps
+import DataStructures: OrderedDict
 import NamedTuples
 import Clustering: Hclust
 

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -11,6 +11,8 @@ import IterableTables
 import DataValues: DataValue
 import TableTraits: column_types, column_names, getiterator, isiterabletable
 import TableTraitsUtils: create_columns_from_iterabletable
+using Widgets
+import Widgets: @nodeps
 import NamedTuples
 import Clustering: Hclust
 
@@ -22,6 +24,7 @@ import KernelDensity
 
 export @df
 
+include("interact.jl")
 include("df.jl")
 include("corrplot.jl")
 include("cornerplot.jl")

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -11,7 +11,7 @@ import IterableTables
 import DataValues: DataValue
 import TableTraits: column_types, column_names, getiterator, isiterabletable
 import TableTraitsUtils: create_columns_from_iterabletable
-using Widgets
+using Widgets, Observables
 import Widgets: @nodeps
 import NamedTuples
 import Clustering: Hclust

--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -24,8 +24,8 @@ import KernelDensity
 
 export @df
 
-include("interact.jl")
 include("df.jl")
+include("interact.jl")
 include("corrplot.jl")
 include("cornerplot.jl")
 include("distributions.jl")

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -26,6 +26,6 @@
         $(:plot)
         y = (:y_toggle[] && !isempty(:y[])) ? [:y[]] : []
         by = (:by_toggle[] && !isempty(:by[])) ? [(^(:group), :by[])] : []
-        @df t :plot_type(:x[], y..., by..., nbins = $(:nbins_throttle))
+        @df t :plot_type[](:x[], y..., by..., nbins = $(:nbins_throttle))
     end
 end

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -37,11 +37,17 @@
             plot()
         else
             x = hcat(getindex.(d, :x[])...)
-            y = (:y_toggle[] && !isempty(:y[])) ? [hcat(getindex.(d, :y[])...)] : []
-            by = (:by_toggle[] && !isempty(:by[])) ? [(^(:group), Tuple(getindex.(d, :by[])))] : []
+            has_y = (:y_toggle[] && !isempty(:y[]))
+            y = has_y ? [hcat(getindex.(d, :y[])...)] : []
+            by = (:by_toggle[] && !isempty(:by[])) ? [(^(:group), NamedTuples.make_tuple(:by[])(getindex.(d, :by[])...))] : []
             label = length(:x[]) > 1 ? [(^(:label), :x[])] :
-                    (:y_toggle[] && length(:y[]) > 1) ? [(^(:label), :y[])] : []
-            :plot_type[](x, y...; nbins = $(:nbins_throttle), by..., label...)
+                    (:y_toggle[] && length(:y[]) > 1) ? [(^(:label), :y[])] :
+                    isempty(by) ? [(^(:label), "")] : []
+            densityplot1D = :plot_type[] in [density, histogram]
+            xlabel = (length(:x[]) == 1 && (densityplot1D || has_y)) ? [(^(:xlabel), :x[][1])] : []
+            ylabel = (:y_toggle[] && length(:y[]) == 1) ? [(^(:ylabel), :y[][1])] :
+                     (!has_y && !densityplot1D && length(:x[]) == 1) ? [(^(:ylabel), :x[][1])] : []
+            :plot_type[](x, y...; nbins = $(:nbins_throttle), by..., label..., xlabel..., ylabel...)
         end
     end
     @layout! wdg Widgets.div(

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -1,0 +1,31 @@
+@widget wdg function interactstats(t; throttle = 0.1)
+    :names = StatPlots.column_names(StatPlots.getiterator(t))
+    :x =  @nodeps dropdown(:names, placeholder = "First axis")
+    :y =  @nodeps dropdown(:names, placeholder = "Second axis")
+    wdg[:y_toggle] = @nodeps togglecontent(wdg[:y], value = false, label = "Second axis")
+    :plot_type = @nodeps dropdown(
+        [
+            plot,
+            scatter,
+            grupedbar,
+            boxplot,
+            corrplot,
+            cornerplot,
+            density,
+            histogram,
+            marginalhist,
+            violin
+        ],
+        placeholder = "Plot type")
+    :nbins =  @nodeps slider(1:100, value = 30, label = "number of bins")
+    :nbins_throttle = Observables.throttle(throttle, :nbins)
+    :by = @nodeps dropdown(:names, multiple = true, placeholder="Group by")
+    wdg[:by_toggle] = @nodeps togglecontent(wdg[:by], value = false, label = "Split data")
+    :plot = @nodeps button("plot")
+    @output! wdg begin
+        $(:plot)
+        y = (:y_toggle[] && !isempty(:y[])) ? [:y[]] : []
+        by = (:by_toggle[] && !isempty(:by[])) ? [(^(:group), :by[])] : []
+        @df t :plot_type(:x[], y..., by..., nbins = $(:nbins_throttle))
+    end
+end

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -1,4 +1,4 @@
-@widget wdg function dataviewer(t; throttle = 0.1)
+@widget wdg function dataviewer(t; throttle = 0.1, nbins = 30, nbins_range = 1:100)
     cols, colnames = create_columns_from_iterabletable(getiterator(t))
     :names = colnames
     d = Dict((key, convert_missing.(val)) for (key, val)  in zip(colnames, cols))
@@ -19,8 +19,12 @@
             "violin"       => violin
         ),
         placeholder = "Plot type")
-    :nbins =  @nodeps slider(1:100, value = 30, label = "number of bins")
+
+    # Add bins if the plot allows it
+    :display_nbins = $(:plot_type) in [corrplot, cornerplot, histogram, marginalhist] ? "block" : "none"
+    :nbins =  (@nodeps slider(nbins_range, value = nbins, label = "number of bins"))(style = Dict("display" => $(:display_nbins)))
     :nbins_throttle = Observables.throttle(throttle, :nbins)
+
     :by = @nodeps dropdown(:names, multiple = true, placeholder="Group by")
     wdg[:by_toggle] = @nodeps togglecontent(wdg[:by], value = false, label = "Split data")
     :plot = @nodeps button("plot")

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -45,14 +45,13 @@
             :y_toggle,
             :plot_type,
             :by_toggle,
-            :plot,
-            className = "column is-4"
+            :plot
         ),
+        Widgets.div(style = Dict("width" => "3em")),
         Widgets.div(
             _.output,
-            :nbins,
-            className = "column is-8"
+            :nbins
         ),
-        className = "columns"
+        style = Dict("display" => "flex", "direction" => "row")
     )
 end

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -1,4 +1,4 @@
-@widget wdg function interactstats(t; throttle = 0.1)
+@widget wdg function dataviewer(t; throttle = 0.1)
     cols, colnames = create_columns_from_iterabletable(getiterator(t))
     :names = colnames
     d = Dict((key, convert_missing.(val)) for (key, val)  in zip(colnames, cols))

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -1,13 +1,13 @@
 @widget wdg function interactstats(t; throttle = 0.1)
     :names = StatPlots.column_names(StatPlots.getiterator(t))
-    :x =  @nodeps dropdown(:names, placeholder = "First axis")
-    :y =  @nodeps dropdown(:names, placeholder = "Second axis")
+    :x =  @nodeps dropdown(:names, placeholder = "First axis", multiple = true)
+    :y =  @nodeps dropdown(:names, placeholder = "Second axis", multiple = true)
     wdg[:y_toggle] = @nodeps togglecontent(wdg[:y], value = false, label = "Second axis")
     :plot_type = @nodeps dropdown(
         [
             plot,
             scatter,
-            grupedbar,
+            groupedbar,
             boxplot,
             corrplot,
             cornerplot,
@@ -26,6 +26,26 @@
         $(:plot)
         y = (:y_toggle[] && !isempty(:y[])) ? [:y[]] : []
         by = (:by_toggle[] && !isempty(:by[])) ? [(^(:group), :by[])] : []
-        @df t :plot_type[](:x[], y..., by..., nbins = $(:nbins_throttle))
+        if (:plot[] == 0)
+            plot()
+        else
+            @df t :plot_type[](:x[], y..., by..., nbins = $(:nbins_throttle))
+        end
     end
+    @layout! wdg Widgets.div(
+        Widgets.div(
+            :x,
+            :y_toggle,
+            :plot_type,
+            :by_toggle,
+            :plot,
+            className = "column is-4"
+        ),
+        Widgets.div(
+            _.output,
+            :nbins,
+            className = "column is-8"
+        ),
+        className = "columns"
+    )
 end

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -4,18 +4,18 @@
     :y =  @nodeps dropdown(:names, placeholder = "Second axis", multiple = true)
     wdg[:y_toggle] = @nodeps togglecontent(wdg[:y], value = false, label = "Second axis")
     :plot_type = @nodeps dropdown(
-        [
-            plot,
-            scatter,
-            groupedbar,
-            boxplot,
-            corrplot,
-            cornerplot,
-            density,
-            histogram,
-            marginalhist,
-            violin
-        ],
+        OrderedDict(
+            "line"         => plot,
+            "scatter"      => scatter,
+            "bar"          => groupedbar,
+            "boxplot"      => boxplot,
+            "corrplot"     => corrplot,
+            "cornerplot"   => cornerplot,
+            "density"      => density,
+            "histogram"    => histogram,
+            "marginalhist" => marginalhist,
+            "violin"       => violin
+        ),
         placeholder = "Plot type")
     :nbins =  @nodeps slider(1:100, value = 30, label = "number of bins")
     :nbins_throttle = Observables.throttle(throttle, :nbins)

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -34,7 +34,9 @@
             x = hcat(getindex.(d, :x[])...)
             y = (:y_toggle[] && !isempty(:y[])) ? [hcat(getindex.(d, :y[])...)] : []
             by = (:by_toggle[] && !isempty(:by[])) ? [(^(:group), Tuple(getindex.(d, :by[])))] : []
-            :plot_type[](x, y...; nbins = $(:nbins_throttle), by...)
+            label = length(:x[]) > 1 ? [(^(:label), :x[])] :
+                    (:y_toggle[] && length(:y[]) > 1) ? [(^(:label), :y[])] : []
+            :plot_type[](x, y...; nbins = $(:nbins_throttle), by..., label...)
         end
     end
     @layout! wdg Widgets.div(

--- a/src/interact.jl
+++ b/src/interact.jl
@@ -22,7 +22,8 @@
 
     # Add bins if the plot allows it
     :display_nbins = $(:plot_type) in [corrplot, cornerplot, histogram, marginalhist] ? "block" : "none"
-    :nbins =  (@nodeps slider(nbins_range, value = nbins, label = "number of bins"))(style = Dict("display" => $(:display_nbins)))
+    :nbins =  (@nodeps slider(nbins_range, extra_obs = ["display" => :display_nbins], value = nbins, label = "number of bins"))
+    wdg[:nbins].scope.dom = Widgets.div(wdg[:nbins].scope.dom, attributes = Dict("data-bind" => "style: {display: display}"))
     :nbins_throttle = Observables.throttle(throttle, :nbins)
 
     :by = @nodeps dropdown(:names, multiple = true, placeholder="Group by")


### PR DESCRIPTION
This is a work in progress (though I'd like to merge soonish marked as "experimental" to get feedback).

It creates a small GUI starting from a table to create plots interactively. The user can select one or more columns as first variable, then one or more columns as second variable (or none), plot type and whether to split by some columns:

```julia
import RDatasets
iris = RDatasets.dataset("datasets", "iris")
using StatPlots, Interact
interactstats(iris)
```

![interactstats](https://user-images.githubusercontent.com/6333339/43359702-abd82d74-929e-11e8-8fc9-b589287f1c23.png)