### PR TITLE
Explicitly state that module should not be precompiled

### DIFF
--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -1,4 +1,4 @@
-
+__precompile__(false)
 module StatPlots
 
 using Reexport


### PR DESCRIPTION
Precompilation breaks StatPlots, possibly due to Reexport