### PR TITLE
Multiple columns in groupedbar

### DIFF
--- a/src/bar.jl
+++ b/src/bar.jl
@@ -6,6 +6,7 @@ end
 
 grouped_xy(x::AbstractVector, y::AbstractMatrix) = x, y
 grouped_xy(y::AbstractMatrix) = 1:size(y,1), y
+grouped_xy(x::AbstractVector, y::AbstractVector{<:AbstractVector}) = x, hcat(y...)
 
 @recipe function f(g::GroupedBar)
     x, y = grouped_xy(g.args...)


### PR DESCRIPTION
This adds the ability to do
```
@df d groupedbar(:y, [:x1, :x2, :x3], bar_position=:dodge)
```
instead of manually having to manually transform the desired columns to a matrix.