### PR TITLE
Convert isnull to 1.0 equivalent

### DIFF
--- a/src/df.jl
+++ b/src/df.jl
@@ -165,7 +165,7 @@ function extract_columns_from_iterabletable(df, syms...)
 end
 
 convert_missing(el) = el
-convert_missing(el::DataValue{T}) where {T} = isnull(el) ? error("Missing data of type $T is not supported") : el.value
+convert_missing(el::DataValue{T}) where {T} = (el === nothing) ? error("Missing data of type $T is not supported") : el.value
 convert_missing(el::DataValue{<:AbstractString}) = get(el, "")
 convert_missing(el::DataValue{Symbol}) = get(el, Symbol())
 convert_missing(el::DataValue{<:Real}) = get(convert(DataValue{Float64}, el), NaN)


### PR DESCRIPTION
Convert `isnull` call to the equivalent ` === nothing` comparison in Julia 1.0