### PR TITLE
Re-enable precompilation for StatPlots.

### DIFF
--- a/src/StatPlots.jl
+++ b/src/StatPlots.jl
@@ -1,4 +1,3 @@
-__precompile__(false)
 module StatPlots
 
 using Reexport


### PR DESCRIPTION
After the heroic https://github.com/JuliaPlots/Plots.jl/pull/1772, StatPlots now precompiles successfully, and so
no longer needs to opt-out of precompilation!

Thanks @daschw! :)


This drops the time for `using StatPlots` by more than half, where most
of the remaining time is now spent importing Plots.