### PR TITLE
Grouped box- and violin plots

### DIFF
--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -23,7 +23,7 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     @assert whisker_width == :match || whisker_width >= 0 "whisker_width must be :match or a positive number"
     ww = whisker_width == :match ? bw : whisker_width
 
-    plotattributes[:group] == nothing ? ngroups = 1 : ngroups = length(unique(plotattributes[:group]))
+    isa(plotattributes[:group], Nothing) ? ngroups = 1 : ngroups = length(unique(plotattributes[:group]))
     thisgroup = plotattributes[:series_plotindex]
 
     outercenter = 0.5 * bw - bw / 2ngroups

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -23,7 +23,7 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     @assert whisker_width == :match || whisker_width >= 0 "whisker_width must be :match or a positive number"
     ww = whisker_width == :match ? bw : whisker_width
 
-    ngroups = length(unique(plotattributes[:group]))
+    plotattributes[:group] == nothing ? ngroups = 1 : ngroups = length(unique(plotattributes[:group]))
     thisgroup = plotattributes[:series_plotindex]
 
     outercenter = 0.5 * bw - bw / 2ngroups

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -21,6 +21,24 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     bw == nothing && (bw = 0.8)
     @assert whisker_width == :match || whisker_width >= 0 "whisker_width must be :match or a positive number"
     ww = whisker_width == :match ? bw : whisker_width
+
+    nr, nc = size(y)
+    x = if nc == 1
+        x
+    else
+        bws = bw / nc
+        bar_width := bws
+        xmat = zeros(nr,nc)
+        for r=1:nr
+            loopbw = _cycle(bws, r)
+            farleft = xnums[r] - 0.5 * (loopbw * nc)
+            for c=1:nc
+                xmat[r,c] = farleft + 0.5loopbw + (c-1)*loopbw
+            end
+        end
+        xmat
+    end
+
     for (i,glabel) in enumerate(glabels)
         # filter y
         values = y[filter(i -> _cycle(x,i) == glabel, 1:length(y))]

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -28,15 +28,14 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
 
     outercenter = 0.5 * bw - bw / 2ngroups
     offsets = collect(-outercenter:(bw / ngroups):outercenter)
+    bw = bw / ngroups
+    ww = ww / ngroups
 
-    @info "offsets" offsets
-    # x = x .+ offsets[thisgroup]
+    @info "offset" offsets[thisgroup]
 
-    @info "x" x
     for (i,glabel) in enumerate(glabels)
         # filter y
         values = y[filter(i -> _cycle(x,i) == glabel, 1:length(y))]
-        @info "y" y
         # compute quantiles
         q1,q2,q3,q4,q5 = quantile(values, Base.range(0,stop=1,length=5))
 
@@ -51,6 +50,9 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
 
         # make the shape
         center = Plots.discrete_value!(plotattributes[:subplot][:xaxis], glabel)[1]
+        center = center + offsets[thisgroup]
+        @warn center
+        @warn typeof(center)
 
         hw = 0.5_cycle(bw, i) # Box width
         HW = 0.5_cycle(ww, i) # Whisker width

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -31,8 +31,6 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     bw = bw / ngroups
     ww = ww / ngroups
 
-    @info "offset" offsets[thisgroup]
-
     for (i,glabel) in enumerate(glabels)
         # filter y
         values = y[filter(i -> _cycle(x,i) == glabel, 1:length(y))]
@@ -51,8 +49,6 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
         # make the shape
         center = Plots.discrete_value!(plotattributes[:subplot][:xaxis], glabel)[1]
         center = center + offsets[thisgroup]
-        @warn center
-        @warn typeof(center)
 
         hw = 0.5_cycle(bw, i) # Box width
         HW = 0.5_cycle(ww, i) # Whisker width

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -99,9 +99,9 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     if outliers
         @series begin
             seriestype  := :scatter
-	    if get!(plotattributes, :markershape, :circle) == :none
-            	plotattributes[:markershape] = :circle
-	    end
+        if get!(plotattributes, :markershape, :circle) == :none
+                plotattributes[:markershape] = :circle
+        end
             markercolor := plotattributes[:fillcolor]
             markerstrokecolor := plotattributes[:linecolor]
             fillrange   := nothing

--- a/src/boxplot.jl
+++ b/src/boxplot.jl
@@ -22,7 +22,8 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
     @assert whisker_width == :match || whisker_width >= 0 "whisker_width must be :match or a positive number"
     ww = whisker_width == :match ? bw : whisker_width
 
-    nr, nc = size(y)
+    nr, nc = size(y) # size(y) == (6,)
+
     x = if nc == 1
         x
     else
@@ -110,7 +111,7 @@ notch_width(q2, q4, N) = 1.58 * (q4-q2)/sqrt(N)
 
     # To prevent linecolor equal to fillcolor (It makes the median visible)
     if plotattributes[:linecolor] == plotattributes[:fillcolor]
-	plotattributes[:linecolor] = plotattributes[:markerstrokecolor]
+        plotattributes[:linecolor] = plotattributes[:markerstrokecolor]
     end
 
     # Outliers

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -28,6 +28,14 @@ end
     glabels = sort(collect(unique(x)))
     bw = plotattributes[:bar_width]
     bw == nothing && (bw = 0.8)
+
+    ngroups = length(unique(plotattributes[:group]))
+    thisgroup = plotattributes[:series_plotindex]
+
+    outercenter = 0.5 * bw - bw / 2ngroups
+    offsets = collect(-outercenter:(bw / ngroups):outercenter)
+    bw = bw / ngroups
+
     for (i,glabel) in enumerate(glabels)
         widths, centers = violin_coords(y[filter(i -> _cycle(x,i) == glabel, 1:length(y))], trim=trim)
         isempty(widths) && continue
@@ -38,6 +46,8 @@ end
 
         # make the violin
         xcenter = Plots.discrete_value!(plotattributes[:subplot][:xaxis], glabel)[1]
+        xcenter = xcenter + offsets[thisgroup]
+
         if (side==:right)
           xcoords = vcat(widths, zeros(length(widths))) .+ xcenter
         elseif (side==:left)

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -29,7 +29,7 @@ end
     bw = plotattributes[:bar_width]
     bw == nothing && (bw = 0.8)
 
-    plotattributes[:group] == nothing ? ngroups = 1 : ngroups = length(unique(plotattributes[:group]))
+    isa(plotattributes[:group], Nothing) ? ngroups = 1 : ngroups = length(unique(plotattributes[:group]))
     thisgroup = plotattributes[:series_plotindex]
 
     outercenter = 0.5 * bw - bw / 2ngroups

--- a/src/violin.jl
+++ b/src/violin.jl
@@ -29,7 +29,7 @@ end
     bw = plotattributes[:bar_width]
     bw == nothing && (bw = 0.8)
 
-    ngroups = length(unique(plotattributes[:group]))
+    plotattributes[:group] == nothing ? ngroups = 1 : ngroups = length(unique(plotattributes[:group]))
     thisgroup = plotattributes[:series_plotindex]
 
     outercenter = 0.5 * bw - bw / 2ngroups


### PR DESCRIPTION
Goal to address #145 . Testing with:

```
using Random
using DataFrames
using StatPlots

df = DataFrame(x=repeat([1,2,3],4), y=rand(12), g=vcat(fill("a", 6), fill("b", 6))
    )

@df df groupedbar(:x, :y, group=:g)
```
![screen shot 2018-10-11 at 14 23 45](https://user-images.githubusercontent.com/3502975/46825313-55cfbe80-cd61-11e8-9256-9b89a3651e0a.png)

```
@df df boxplot(:x, :y, group=:g)
```
![screen shot 2018-10-11 at 14 24 38](https://user-images.githubusercontent.com/3502975/46825351-6a13bb80-cd61-11e8-9f84-5e5161cff026.png)


```
@df df violin(:x, :y, group=:g)
```
![screen shot 2018-10-11 at 14 25 04](https://user-images.githubusercontent.com/3502975/46825368-78fa6e00-cd61-11e8-8afa-eb2364aff56e.png)

EDIT: this also addresses #56 and #89